### PR TITLE
Update CI to fix GitHub Actions run issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     name: Lint and Test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version-file: .python-version
 


### PR DESCRIPTION
### Motivation and Context

Applying updated CI steps, as already implemented in Converter and Proxy

### What has changed

Reorder steps in CI, so that Python is installed before running poetry, to ensure actions run in correct Python version

### How to test?

Check no issues
