### PR TITLE
Add url ignore linting pattern

### DIFF
--- a/.github/linters/.markdown-link-check.json
+++ b/.github/linters/.markdown-link-check.json
@@ -1,5 +1,9 @@
 {
-  "ignorePatterns": [],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://www\\.npmjs\\.com/"
+    }
+  ],
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "30s"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To run the UI in debug mode, you can add a root `.env` file, and add the setting
 
 ## ONS Design System
 
-The ONS design system needs to be installed using [npm](https://www.npmjs.com/package/npm).
+The ONS design system needs to be installed using [npm](https://www.npmjs.com/).
 To install the ONS Design System npm package you will need to install [node.js](https://nodejs.org/en/).
 To do this, use the following commands:
 


### PR DESCRIPTION
### Motivation and Context

Due to a change on the website end, the npm url in the readme returns a 403 when linting, causing a MegaLinter failure

### What has changed

Adds a specific ignore pattern for the npm website url, to allow the url to stay in the readme without causing a linting failure

### How to test?

Confirm that MegaLinter tests has passed on this PR build
